### PR TITLE
clean up trip transformation

### DIFF
--- a/app/transformations/trip.py
+++ b/app/transformations/trip.py
@@ -10,11 +10,8 @@ def prep_trip_data():
 df_trip = prep_trip_data()
 
 def transform_df_trip(data):
-    # data.dropna(axis=0, how='any', inplace=True)
-    data['duration'] /= 60
     data.start_date = pd.to_datetime(data.start_date, format='%m/%d/%Y %H:%M')
     data['date'] = data.start_date.dt.date
-    # data.drop(["start_station_name", "end_date", "bike_id", "subscription_type", "start_station_id", "end_station_name", "end_station_id"], 1, inplace=True)
 
     dates = {}
     for d in data.date:
@@ -22,8 +19,6 @@ def transform_df_trip(data):
             dates[d] = 1
         else:
             dates[d] += 1
-
-    dates
 
     data.drop("start_date", 1, inplace=True)
     df = pd.DataFrame.from_dict(dates, orient = "index")
@@ -36,13 +31,3 @@ def transform_df_trip(data):
     return trips_train
 
 trips_train = transform_df_trip(df_trip)
-# this returns:
-#            date  trips
-# 0    2013-08-29    748
-# 1    2013-08-30    714
-# 2    2013-08-31    640
-# 3    2013-09-01    706
-
-
-# trips_per_day = {}
-# trips_per_day = transformed_trip.to_dict(orient="list")


### PR DESCRIPTION
Removes more complicated transformations to simplify the process to get to predictions more quickly. In the future, we can come back and add more complexity if necessary.